### PR TITLE
feat: add button visual variants

### DIFF
--- a/lib/Button/Button.css
+++ b/lib/Button/Button.css
@@ -1,0 +1,57 @@
+.uglyworkgood-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  border: 1px solid transparent;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.uwg-variant-solid {
+  background-color: #1f2937;
+  color: #ffffff;
+}
+
+.uwg-variant-outline {
+  background-color: transparent;
+  color: #1f2937;
+  border-color: currentColor;
+}
+
+.uwg-variant-ghost {
+  background-color: transparent;
+  color: #1f2937;
+}
+
+.uwg-variant-link {
+  background: none;
+  color: #2563eb;
+  padding: 0;
+  border-color: transparent;
+}
+
+.uwg-variant-dashed {
+  background-color: transparent;
+  color: #1f2937;
+  border-color: currentColor;
+  border-style: dashed;
+}
+
+.uwg-spinner {
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  width: 1em;
+  height: 1em;
+  animation: uwg-spin 0.75s linear infinite;
+}
+
+@keyframes uwg-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/lib/Button/Button.tsx
+++ b/lib/Button/Button.tsx
@@ -4,10 +4,11 @@ import React, {
   type ButtonHTMLAttributes,
   type ReactNode,
 } from 'react';
+import './Button.css';
 
 type CommonProps = {
   children?: ReactNode;
-  variant?: 'solid' | 'outline' | 'ghost' | 'link';
+  variant?: 'solid' | 'outline' | 'ghost' | 'link' | 'dashed';
   size?: 'sm' | 'md' | 'lg';
   fullWidth?: boolean;
   loading?: boolean;


### PR DESCRIPTION
## Summary
- add optional dashed variant and load component styles
- style solid, outline, ghost, link, and dashed button types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bf42c18e08324a45fcf432984c35e