### PR TITLE
feat: add terminal component

### DIFF
--- a/lib/Terminal/Terminal.css
+++ b/lib/Terminal/Terminal.css
@@ -1,0 +1,32 @@
+.uglyworkgood-terminal {
+  background-color: #000;
+  color: #0f0;
+  padding: 1rem;
+  font-family: monospace;
+}
+
+.uwg-terminal-lines {
+  min-height: 10rem;
+  margin-bottom: 0.5rem;
+}
+
+.uwg-terminal-line {
+  white-space: pre-wrap;
+}
+
+.uwg-terminal-input {
+  display: flex;
+}
+
+.uwg-terminal-prompt {
+  margin-right: 0.5rem;
+}
+
+.uwg-terminal-input input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  outline: none;
+}

--- a/lib/Terminal/Terminal.tsx
+++ b/lib/Terminal/Terminal.tsx
@@ -1,0 +1,73 @@
+import {
+  forwardRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from 'react';
+import './Terminal.css';
+
+export interface TerminalLine {
+  text: string;
+  type?: 'command' | 'output';
+}
+
+export interface TerminalProps {
+  lines?: TerminalLine[];
+  prompt?: string;
+  onCommand?: (command: string) => void;
+  className?: string;
+}
+
+function cx(...parts: Array<string | false | null | undefined>) {
+  return parts.filter(Boolean).join(' ');
+}
+
+export const Terminal = forwardRef<HTMLDivElement, TerminalProps>((props, ref) => {
+  const { lines = [], prompt = '$', onCommand, className } = props;
+  const [value, setValue] = useState('');
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      onCommand?.(value);
+      setValue('');
+    }
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+  };
+
+  return (
+    <div ref={ref} className={cx('uglyworkgood-terminal', className)}>
+      <div className="uwg-terminal-lines">
+        {lines.map((line, idx) => (
+          <div
+            key={idx}
+            className={cx('uwg-terminal-line', line.type === 'command' && 'uwg-terminal-command')}
+          >
+            {line.type === 'command' ? (
+              <>
+                <span className="uwg-terminal-prompt">{prompt}</span>
+                {line.text}
+              </>
+            ) : (
+              line.text
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="uwg-terminal-input">
+        <span className="uwg-terminal-prompt">{prompt}</span>
+        <input
+          type="text"
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+    </div>
+  );
+});
+
+Terminal.displayName = 'Terminal';
+

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,1 +1,4 @@
 export { Button } from './Button/Button';
+export { Terminal } from './Terminal/Terminal';
+export type { TerminalProps, TerminalLine } from './Terminal/Terminal';
+


### PR DESCRIPTION
## Summary
- add terminal emulator component with command submission support
- export terminal component and types

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bfb4475108324b9b6909c3e5d7be4