### PR TITLE
feat: add command responses to terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,21 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Terminal component
+
+The `Terminal` component accepts a `commands` prop that maps user input to
+terminal output. When a command is entered, the command and the associated
+response are written to the terminal.
+
+```tsx
+import { Terminal } from 'uglyworkgood-design';
+
+<Terminal
+  commands={{
+    help: 'Available commands: help, ping',
+    ping: 'pong',
+  }}
+/>
+```
+

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./lib/globals.d.ts","./lib/main.ts","./lib/Button/Button.tsx"],"version":"5.8.3"}
+{"root":["./lib/globals.d.ts","./lib/main.ts","./lib/Button/Button.tsx","./lib/Terminal/Terminal.tsx"],"version":"5.8.3"}


### PR DESCRIPTION
## Summary
- allow Terminal to map user commands to output lines
- document command mapping and usage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bffb6ba048324a32a026c142ec6f3